### PR TITLE
Add information about contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,39 @@
+# RInform (Glulx) contributors
+
+This is a list of people that contributed to the RInform (Glulx) project
+in various ways. For an overview of contributors, see also
+https://github.com/yandexx/rinform-glulx/graphs/contributors
+
+## Standard library
+
+* English original:
+	- Graham Nelson
+* Modification and Russian localization:
+	- Andrey Grankin
+	- Denis Gayev
+	- Vsevolod Zubarev
+
+## Extended libraries
+
+* English original:
+	- Emily Short
+	- Roger Firth
+* Modification and Russian localization:
+	- Denis Gayev
+
+## Demo games
+
+* English original:
+	- Angela M. Horns
+	- David M. Baggett
+	- Don Woods
+	- Donald Ekman
+	- Gareth Rees
+	- Graham Nelson
+	- Roger Firth
+	- Sonja Kesserich
+	- Will Crowther
+* Modification and Russian localization:
+	- Alexander Mospan a.k.a. Ugo
+	- Denis Gayev
+	- Yuri Saltykov a.k.a. G.A. Garinson


### PR DESCRIPTION
The list of contributors is compiled on the basis of copyrights indicated explicitly in the source files.