### PR TITLE
Ubdate links to RInform chats

### DIFF
--- a/libext/HelpRoutines.h
+++ b/libext/HelpRoutines.h
@@ -640,8 +640,7 @@ system_file;
 
 [ MoreGames;
 	print (ESB) "РУССКОЯЗЫЧНОЕ ИЛ-СООБЩЕСТВО^^";
-	print "Дружелюбный Discord-сервер: https://discord.gg/X86kkzM^^";
+	print "Дружелюбный Discord-сервер: https://discord.gg/MdT2ZnQ^^";
 	print "Главный форум, посвящённый интерактивной литературе, написанной для любых платформ: http://ifiction.ru/^^";
 	print "Сайт, посвящённый русской адаптации платформы Inform (на которой написана эта игра), http://rinform.org/^^";
-	print "IRC-канал, на котором можно найти активных участников сообщества: #ifrus в сети irc.forestnet.org^";
 ];


### PR DESCRIPTION
* The link with the invalid Discord chat invitation has been replaced with a valid link from the RInform website.
* The link to the IRC chat has been deleted since the forestnet.org website has been unavailable for a long time.